### PR TITLE
Cleanup, formatting and fix for multiplatform

### DIFF
--- a/rockboxalbumfix.py
+++ b/rockboxalbumfix.py
@@ -1,5 +1,4 @@
 import os
-import io
 import shutil
 import time
 from PIL import Image, UnidentifiedImageError
@@ -9,9 +8,14 @@ import tkinter as tk
 from tkinter import filedialog
 from eyed3 import id3
 from mutagen import File
+import tempfile
+
 
 def sanitize_filename(filename):
-    return ''.join(c if c.isalnum() or c in ['.', '_', '-', ' '] else '_' for c in filename)
+    return "".join(
+        c if c.isalnum() or c in [".", "_", "-", " "] else "_" for c in filename
+    )
+
 
 def get_album_tag(file_path):
     if file_path.endswith(".mp3"):
@@ -26,6 +30,7 @@ def get_album_tag(file_path):
         except Exception as e:
             print(f"Error reading FLAC metadata for {file_path}: {e}")
             return None
+
 
 def organize_music_files(root_dir):
     for filename in os.listdir(root_dir):
@@ -44,28 +49,40 @@ def organize_music_files(root_dir):
                     shutil.move(file_path, os.path.join(album_folder, filename))
                     print(f"Moved '{filename}' to '{sanitized_album_tag}' folder.")
                 except Exception as e:
-                    print(f"Error moving '{filename}' to '{sanitized_album_tag}' folder: {e}")
+                    print(
+                        f"Error moving '{filename}' to '{sanitized_album_tag}' folder: {e}"
+                    )
 
                 time.sleep(0.1)
+
 
 def extract_cover_ffmpeg(directory, temp_folder):
     print(f"\nChecking directory: {directory}")
     files = os.listdir(directory)
 
-    if 'cover.jpg' in files:
+    if "cover.jpg" in files:
         print(f"Cover image found in {directory}")
     else:
-        image_files = [file for file in files if file.lower().endswith(('.jpg', '.jpeg', '.png'))]
+        image_files = [
+            file for file in files if file.lower().endswith((".jpg", ".jpeg", ".png"))
+        ]
 
         if image_files:
             print("Image files found in the directory:")
             for i, image_file in enumerate(image_files, start=1):
                 print(f"{i}. {image_file}")
 
-            selected_index = int(input("Enter the number of the image file you want to use as the cover image: ")) - 1
+            selected_index = (
+                int(
+                    input(
+                        "Enter the number of the image file you want to use as the cover image: "
+                    )
+                )
+                - 1
+            )
             selected_image_file = image_files[selected_index]
 
-            cover_dest_path = os.path.join(directory, 'cover.jpg')
+            cover_dest_path = os.path.join(directory, "cover.jpg")
             shutil.move(os.path.join(directory, selected_image_file), cover_dest_path)
             print(f"Selected image file '{selected_image_file}' set as cover image.")
 
@@ -76,28 +93,35 @@ def extract_cover_ffmpeg(directory, temp_folder):
                     print(f"Deleted redundant image file '{image_file}'.")
 
         else:
-         flac_files = [file for file in files if file.endswith('.flac')]
-        mp3_files = [file for file in files if file.endswith('.mp3')]
+            flac_files = [file for file in files if file.endswith(".flac")]
+        mp3_files = [file for file in files if file.endswith(".mp3")]
 
         if flac_files:
             flac_file_path = os.path.join(directory, flac_files[0])
-            temp_folder_path = os.path.join(temp_folder, 'cover_extraction_temp')
+            temp_folder_path = os.path.join(temp_folder, "cover_extraction_temp")
 
             try:
                 os.makedirs(temp_folder_path, exist_ok=True)
 
-                encoding = sys.stdout.encoding or 'utf-8'
-                temp_cover_path = os.path.join(temp_folder_path, 'cover.jpg')
+                encoding = sys.stdout.encoding or "utf-8"
+                temp_cover_path = os.path.join(temp_folder_path, "cover.jpg")
                 print(f"Running ffmpeg command for '{flac_file_path}'")
-                result = subprocess.run(['ffmpeg', '-i', flac_file_path, temp_cover_path], text=True, capture_output=True, encoding=encoding)
+                result = subprocess.run(
+                    ["ffmpeg", "-i", flac_file_path, temp_cover_path],
+                    text=True,
+                    capture_output=True,
+                    encoding=encoding,
+                )
 
                 print(f"\nffmpeg command output: {result.stdout}")
                 print(f"ffmpeg command error: {result.stderr}")
 
                 if result.returncode == 0:
-                    cover_dest_path = os.path.join(directory, 'cover.jpg')
+                    cover_dest_path = os.path.join(directory, "cover.jpg")
                     shutil.move(temp_cover_path, cover_dest_path)
-                    print(f"FLAC Cover image extracted and saved as baseline JPEG in {directory}")
+                    print(
+                        f"FLAC Cover image extracted and saved as baseline JPEG in {directory}"
+                    )
             except Exception as e:
                 print(f"Error during extraction: {e}")
             finally:
@@ -105,27 +129,35 @@ def extract_cover_ffmpeg(directory, temp_folder):
 
         elif mp3_files:
             mp3_file_path = os.path.join(directory, mp3_files[0])
-            temp_folder_path = os.path.join(temp_folder, 'cover_extraction_temp')
+            temp_folder_path = os.path.join(temp_folder, "cover_extraction_temp")
 
             try:
                 os.makedirs(temp_folder_path, exist_ok=True)
 
-                encoding = sys.stdout.encoding or 'utf-8'
-                temp_cover_path = os.path.join(temp_folder_path, 'cover.jpg')
+                encoding = sys.stdout.encoding or "utf-8"
+                temp_cover_path = os.path.join(temp_folder_path, "cover.jpg")
                 print(f"Running ffmpeg command for '{mp3_file_path}'")
-                result = subprocess.run(['ffmpeg', '-i', mp3_file_path, temp_cover_path], text=True, capture_output=True, encoding=encoding)
+                result = subprocess.run(
+                    ["ffmpeg", "-i", mp3_file_path, temp_cover_path],
+                    text=True,
+                    capture_output=True,
+                    encoding=encoding,
+                )
 
                 print(f"\nffmpeg command output: {result.stdout}")
                 print(f"ffmpeg command error: {result.stderr}")
 
                 if result.returncode == 0:
-                    cover_dest_path = os.path.join(directory, 'cover.jpg')
+                    cover_dest_path = os.path.join(directory, "cover.jpg")
                     shutil.move(temp_cover_path, cover_dest_path)
-                    print(f"MP3 Cover image extracted and saved as baseline JPEG in {directory}")
+                    print(
+                        f"MP3 Cover image extracted and saved as baseline JPEG in {directory}"
+                    )
             except Exception as e:
                 print(f"Error during extraction: {e}")
             finally:
                 pass
+
 
 def restore_backups(root_dir):
     print("\nRestoring backups...")
@@ -134,7 +166,7 @@ def restore_backups(root_dir):
             dirs.remove(".rockbox")
 
         for file in files:
-            if file.lower().endswith(('.jpg.backup', '.jpeg.backup', '.png.backup')):
+            if file.lower().endswith((".jpg.backup", ".jpeg.backup", ".png.backup")):
                 backup_path = os.path.join(root, file)
                 original_filename = sanitize_filename(file[:-7])
                 original_path = os.path.join(root, original_filename)
@@ -144,6 +176,7 @@ def restore_backups(root_dir):
                     print(f"Restored: '{original_filename}'")
                 else:
                     print(f"Backup not found for: '{original_filename}'")
+
 
 def process_images(root_dir, iteration_timeout=5, max_retries=3):
     retries = 0
@@ -156,7 +189,7 @@ def process_images(root_dir, iteration_timeout=5, max_retries=3):
                 if ".rockbox" in dirs:
                     dirs.remove(".rockbox")
 
-                cover_path = os.path.join(root, 'cover.jpg')
+                cover_path = os.path.join(root, "cover.jpg")
 
                 if root in processed_folders:
                     continue
@@ -166,22 +199,27 @@ def process_images(root_dir, iteration_timeout=5, max_retries=3):
 
                     try:
                         with Image.open(cover_path) as img:
-                            if img.mode in ('RGBA', 'LA'):
-                                img = img.convert('RGB')
+                            if img.mode in ("RGBA", "LA"):
+                                img = img.convert("RGB")
 
                             if img.size != (200, 200):
                                 img = img.resize((200, 200))
-                                img.save(cover_path, 'JPEG', quality=95, subsampling=0)
+                                img.save(cover_path, "JPEG", quality=95, subsampling=0)
                                 print(f"Modified 'cover.jpg' in {root}")
                             else:
-                                print("'cover.jpg' is already a baseline JPEG with dimensions 200x200. Skipping.")
+                                print(
+                                    "'cover.jpg' is already a baseline JPEG with dimensions 200x200. Skipping."
+                                )
 
                     except UnidentifiedImageError as e:
                         print(f"Error processing 'cover.jpg': {str(e)}")
                         continue
 
                 else:
-                    extract_cover_ffmpeg(root, os.path.join(os.getenv('TEMP'), 'cover_extraction_temp'))
+                    extract_cover_ffmpeg(
+                        root,
+                        os.path.join(tempfile.gettempdir(), "cover_extraction_temp"),
+                    )
                     folders_processed += 1
                     processed_folders.add(root)
 
@@ -197,15 +235,19 @@ def process_images(root_dir, iteration_timeout=5, max_retries=3):
     except KeyboardInterrupt:
         print("\nProcessing interrupted by user.")
 
+
 def clear_temp_directory():
-    temp_folder = os.getenv('TEMP')
-    temp_folder_path = os.path.join(temp_folder, 'cover_extraction_temp', 'cover_extraction_temp')
+    temp_folder = os.getenv("TEMP")
+    temp_folder_path = os.path.join(
+        temp_folder, "cover_extraction_temp", "cover_extraction_temp"
+    )
 
     if os.path.exists(temp_folder_path):
         shutil.rmtree(temp_folder_path)
         print(f"Cleared directory: {temp_folder_path}")
     else:
         print(f"Directory does not exist: {temp_folder_path}")
+
 
 if __name__ == "__main__":
     root = tk.Tk()

--- a/rockboxalbumfix.py
+++ b/rockboxalbumfix.py
@@ -237,7 +237,7 @@ def process_images(root_dir, iteration_timeout=5, max_retries=3):
 
 
 def clear_temp_directory():
-    temp_folder = os.getenv("TEMP")
+    temp_folder = tempfile.gettempdir()
     temp_folder_path = os.path.join(
         temp_folder, "cover_extraction_temp", "cover_extraction_temp"
     )


### PR DESCRIPTION
This PR adds support for other OS's by using tempfile instead of relying on an env variable for getting the temporary directory, also formats the code using the black formatter and removes an unused import