### PR TITLE
Fix crash caused by "flac_files" not existing

### DIFF
--- a/rockboxalbumfix.py
+++ b/rockboxalbumfix.py
@@ -91,6 +91,7 @@ def extract_cover_ffmpeg(directory, temp_folder):
                 if image_file != selected_image_file:
                     os.remove(os.path.join(directory, image_file))
                     print(f"Deleted redundant image file '{image_file}'.")
+            flac_files = None
 
         else:
             flac_files = [file for file in files if file.endswith(".flac")]


### PR DESCRIPTION
I was getting a crash after converting .png cover art using this tool. This fixes the error.
Closes #2.